### PR TITLE
DEV-661: ht_maintenance db user for slip

### DIFF
--- a/etc/ht_maintenance.conf
+++ b/etc/ht_maintenance.conf
@@ -1,0 +1,1 @@
+ht_web.conf

--- a/etc/ht_web.conf
+++ b/etc/ht_web.conf
@@ -1,4 +1,4 @@
-db_server = mariadb
+db_server = mysql-sdr
 db_name   = ht
 db_user   = mdp-lib
 db_passwd = mdp-lib


### PR DESCRIPTION
Trivial addition - slip uses the `ht_maintenance` db config. This works *for now* so long as we only care about reading `slip_rights` for the purpose of running `docs-j`, but at some point this probably needs to use a user with write permission.