### PR TITLE
ETT-310: role switcher for resource sharing

### DIFF
--- a/etc/settings/mdp-lib/switches.json
+++ b/etc/settings/mdp-lib/switches.json
@@ -10,5 +10,11 @@
     "role": "totalAccess",
     "label": "Admin",
     "enabled": 1
+  },
+  {
+    "method": "user_is_resource_sharing_user",
+    "role": "resourceSharing",
+    "label": "Resource Sharing",
+    "enabled": 1
   }
 ]


### PR DESCRIPTION
We'll need to update this file in dev/whatever when we're ready to test this further.

This matches the expected activated role name in the babel PR https://github.com/hathitrust/babel/pull/108/files#diff-600981e81dc2c1690a148ea6ee5e4c9ab5aac1421a75999223e1c7c9150ac9abR1401 but it doesn't match the case for other kinds of users here (`totalAccess`, `enhancedTextProxy`). @moseshll Do we want to change that to `resourceSharing` to match the others?